### PR TITLE
Remove Amplitude integration

### DIFF
--- a/app/usecases/authentication.py
+++ b/app/usecases/authentication.py
@@ -69,8 +69,6 @@ async def authenticate(
         hashed_access_token=hashed_access_token,
     )
 
-    # TODO: log amplitude web_login event
-
     logging.info(
         "User successfully authenticated",
         extra={
@@ -156,8 +154,6 @@ async def initialize_password_reset(
         username=user.username,
         hashed_token=hashed_password_reset_token,
     )
-
-    # TODO: log amplitude (web_)password_reset event
 
     logging.info(
         "User initiated password reset process",

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,9 +9,6 @@ enable_error_code = truthy-bool, truthy-iterable, ignore-without-code, unused-aw
 disable_error_code = var-annotated, has-type
 allow_untyped_defs = True
 
-[mypy-amplitude.*]
-ignore_missing_imports = True
-
 [mypy-orjson.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
## Summary
- Remove TODO comments for Amplitude event logging in `authenticate` and `initialize_password_reset`
- Remove unused `[mypy-amplitude.*]` section from mypy config

Amplitude was never actually integrated (no library, no adapter, no config) -- just placeholder TODOs and a preemptive mypy ignore.

## Test plan
- [ ] Verify service starts and authentication/password-reset flows work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)