### PR TITLE
expire password reset tokens after 1 hour

### DIFF
--- a/app/repositories/password_reset_tokens.py
+++ b/app/repositories/password_reset_tokens.py
@@ -46,6 +46,7 @@ async def fetch_one(hashed_token: str) -> PasswordResetToken | None:
         SELECT id, u, t
         FROM password_recovery
         WHERE k = :hashed_token
+          AND t > NOW() - INTERVAL 1 HOUR
     """
     params = {"hashed_token": hashed_token}
     rec = await app.state.database.fetch_one(query, params)


### PR DESCRIPTION
Fixes #18

Added a time check to the token lookup query. Tokens older than 1 hour are now ignored.