### PR TITLE
Expire password reset tokens one hour after creation

### DIFF
--- a/app/repositories/password_reset_tokens.py
+++ b/app/repositories/password_reset_tokens.py
@@ -4,6 +4,10 @@ from pydantic import BaseModel
 
 import app.state
 
+# A reset token is valid for strictly less than this many seconds after
+# creation; at or beyond it the token is expired. Judged on the DB clock.
+PASSWORD_RESET_TOKEN_TTL_SECONDS = 3600
+
 
 class PasswordResetToken(BaseModel):
     id: int
@@ -18,9 +22,11 @@ READ_PARAMS = """\
 
 
 async def create(*, username: str, hashed_token: str) -> PasswordResetToken:
+    # `t` is set with the same DB clock that expiry is compared against in
+    # fetch_one, rather than relying on the column's schema-level default.
     query = """\
-        INSERT INTO password_recovery (k, u)
-        VALUES (:hashed_token, :username)
+        INSERT INTO password_recovery (k, u, t)
+        VALUES (:hashed_token, :username, NOW())
     """
     params = {"hashed_token": hashed_token, "username": username}
     await app.state.database.execute(query, params)
@@ -42,14 +48,29 @@ async def create(*, username: str, hashed_token: str) -> PasswordResetToken:
 
 
 async def fetch_one(hashed_token: str) -> PasswordResetToken | None:
+    # Expiry is evaluated on the DB clock (NOW()), matching the NOW() written by
+    # create(), so it is immune to app/DB timezone or clock skew. The predicate
+    # is framed as "is valid" so a NULL age fails closed to expired: a NOT NULL
+    # `t` should never yield NULL, but a corrupted/migrated row must not be
+    # silently accepted.
     query = """\
-        SELECT id, u, t
+        SELECT id, u, t,
+               TIMESTAMPDIFF(SECOND, t, NOW()) < :ttl_seconds AS is_valid
         FROM password_recovery
         WHERE k = :hashed_token
     """
-    params = {"hashed_token": hashed_token}
+    params = {
+        "hashed_token": hashed_token,
+        "ttl_seconds": PASSWORD_RESET_TOKEN_TTL_SECONDS,
+    }
     rec = await app.state.database.fetch_one(query, params)
     if rec is None:
+        return None
+
+    if not rec["is_valid"]:
+        # Expired (or otherwise non-valid): delete the dead row and report it as
+        # absent, so callers cannot tell "expired" apart from "never existed".
+        await delete_one(hashed_token)
         return None
 
     return PasswordResetToken(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 mypy
 pre-commit
+pytest
+pytest-asyncio
 types-aiobotocore[s3]
 types-jmespath
 types-pyyaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+import os
+
+# app.settings reads every variable at import time (and fails fast if any is
+# missing), so defaults must be in place before any test imports an app
+# module. Values already present in the environment take precedence.
+_TEST_ENV_DEFAULTS = {
+    "APP_ENV": "test",
+    "APP_HOST": "localhost",
+    "APP_PORT": "80",
+    "CODE_HOTRELOAD": "false",
+    "DB_USER": "test",
+    "DB_PASS": "test",
+    "DB_HOST": "localhost",
+    "DB_PORT": "3306",
+    "DB_NAME": "test",
+    "REDIS_HOST": "localhost",
+    "REDIS_PORT": "6379",
+    "REDIS_DB": "0",
+    "REDIS_USER": "default",
+    "REDIS_PASS": "",
+    "AWS_S3_ENDPOINT_URL": "http://localhost:9000",
+    "AWS_S3_REGION_NAME": "us-east-1",
+    "AWS_S3_BUCKET_NAME": "test",
+    "AWS_S3_ACCESS_KEY_ID": "test",
+    "AWS_S3_SECRET_ACCESS_KEY": "test",
+    "ASSETS_SERVICE_BASE_URL": "http://localhost:9001",
+    "ASSETS_SERVICE_API_KEY": "test",
+    "MAILGUN_BASE_URL": "https://api.mailgun.net",
+    "MAILGUN_DOMAIN_NAME": "test.example.com",
+    "MAILGUN_API_KEY": "test",
+    "RECAPTCHA_SECRET_KEY": "test",
+}
+
+for _key, _value in _TEST_ENV_DEFAULTS.items():
+    os.environ.setdefault(_key, _value)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,44 @@
+import os
+from collections.abc import AsyncIterator
+
+import pytest
+from databases import Database
+
+import app.state
+
+# Mirrors the production (Ripple-lineage) definition of the table.
+CREATE_PASSWORD_RECOVERY_TABLE = """\
+    CREATE TABLE password_recovery (
+        id INT NOT NULL AUTO_INCREMENT,
+        k VARCHAR(80) NOT NULL,
+        u VARCHAR(30) NOT NULL,
+        t TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (id)
+    )
+"""
+
+
+@pytest.fixture
+async def database() -> AsyncIterator[Database]:
+    dsn = os.environ.get("TEST_DB_DSN")
+    if not dsn:
+        pytest.skip(
+            "TEST_DB_DSN is not set "
+            "(e.g. mysql+aiomysql://user:pass@localhost:3306/users_service_test)",
+        )
+
+    db = Database(dsn)
+    try:
+        await db.connect()
+    except Exception as exc:
+        pytest.skip(f"could not connect to TEST_DB_DSN: {exc!r}")
+
+    # Recreate from scratch each test: a pristine schema, and individual tests
+    # may safely ALTER the table (e.g. to exercise a nullable `t`).
+    await db.execute("DROP TABLE IF EXISTS password_recovery")
+    await db.execute(CREATE_PASSWORD_RECOVERY_TABLE)
+    app.state.database = db
+    try:
+        yield db
+    finally:
+        await db.disconnect()

--- a/tests/integration/test_password_reset_token_expiry.py
+++ b/tests/integration/test_password_reset_token_expiry.py
@@ -1,0 +1,163 @@
+from databases import Database
+
+from app import security
+from app.repositories import password_reset_tokens
+from app.repositories.password_reset_tokens import PASSWORD_RESET_TOKEN_TTL_SECONDS
+
+
+def make_hashed_token() -> str:
+    return security.hash_secure_token(security.generate_unhashed_secure_token())
+
+
+async def age_token(database: Database, hashed_token: str, age_seconds: int) -> None:
+    """Backdate a token's creation time on the DB clock (no wall-clock sleeps)."""
+    query = """\
+        UPDATE password_recovery
+        SET t = NOW() - INTERVAL :age_seconds SECOND
+        WHERE k = :hashed_token
+    """
+    params = {"age_seconds": age_seconds, "hashed_token": hashed_token}
+    await database.execute(query, params)
+
+
+async def count_tokens(database: Database, hashed_token: str) -> int:
+    query = """\
+        SELECT COUNT(*) AS cnt
+        FROM password_recovery
+        WHERE k = :hashed_token
+    """
+    rec = await database.fetch_one(query, {"hashed_token": hashed_token})
+    assert rec is not None
+    return int(rec["cnt"])
+
+
+async def test_create_stamps_creation_time_with_db_clock(database: Database) -> None:
+    hashed_token = make_hashed_token()
+    await password_reset_tokens.create(username="cmyui", hashed_token=hashed_token)
+
+    query = """\
+        SELECT TIMESTAMPDIFF(SECOND, t, NOW()) AS age_seconds
+        FROM password_recovery
+        WHERE k = :hashed_token
+    """
+    rec = await database.fetch_one(query, {"hashed_token": hashed_token})
+    assert rec is not None
+    assert 0 <= rec["age_seconds"] <= 30
+
+
+async def test_fresh_token_is_valid(database: Database) -> None:
+    hashed_token = make_hashed_token()
+    await password_reset_tokens.create(username="cmyui", hashed_token=hashed_token)
+
+    result = await password_reset_tokens.fetch_one(hashed_token)
+
+    assert result is not None
+    assert result.username == "cmyui"
+    assert result.hashed_token == hashed_token
+
+
+async def test_missing_token_is_rejected(database: Database) -> None:
+    result = await password_reset_tokens.fetch_one(make_hashed_token())
+
+    assert result is None
+
+
+async def test_token_older_than_ttl_is_rejected(database: Database) -> None:
+    hashed_token = make_hashed_token()
+    await password_reset_tokens.create(username="cmyui", hashed_token=hashed_token)
+    await age_token(database, hashed_token, PASSWORD_RESET_TOKEN_TTL_SECONDS + 60)
+
+    result = await password_reset_tokens.fetch_one(hashed_token)
+
+    assert result is None
+
+
+async def test_expired_token_is_deleted_on_read(database: Database) -> None:
+    hashed_token = make_hashed_token()
+    await password_reset_tokens.create(username="cmyui", hashed_token=hashed_token)
+    await age_token(database, hashed_token, PASSWORD_RESET_TOKEN_TTL_SECONDS + 60)
+
+    await password_reset_tokens.fetch_one(hashed_token)
+
+    assert await count_tokens(database, hashed_token) == 0
+
+
+async def test_token_at_exactly_ttl_is_expired(database: Database) -> None:
+    # The boundary is inclusive: a token exactly TTL seconds old is expired
+    # (tokens are valid strictly for less than the TTL).
+    hashed_token = make_hashed_token()
+    await password_reset_tokens.create(username="cmyui", hashed_token=hashed_token)
+    await age_token(database, hashed_token, PASSWORD_RESET_TOKEN_TTL_SECONDS)
+
+    result = await password_reset_tokens.fetch_one(hashed_token)
+
+    assert result is None
+
+
+async def test_token_just_inside_ttl_is_valid(database: Database) -> None:
+    # A 5 minute margin keeps this deterministic on slow test runs.
+    hashed_token = make_hashed_token()
+    await password_reset_tokens.create(username="cmyui", hashed_token=hashed_token)
+    await age_token(database, hashed_token, PASSWORD_RESET_TOKEN_TTL_SECONDS - 300)
+
+    result = await password_reset_tokens.fetch_one(hashed_token)
+
+    assert result is not None
+
+
+async def test_token_one_second_under_ttl_is_valid(database: Database) -> None:
+    # Tightest valid boundary: age == TTL - 1s. Rule is "valid iff age < TTL".
+    hashed_token = make_hashed_token()
+    await password_reset_tokens.create(username="cmyui", hashed_token=hashed_token)
+    await age_token(database, hashed_token, PASSWORD_RESET_TOKEN_TTL_SECONDS - 1)
+
+    result = await password_reset_tokens.fetch_one(hashed_token)
+
+    assert result is not None
+
+
+async def test_token_one_second_over_ttl_is_expired(database: Database) -> None:
+    # Tightest expired boundary: age == TTL + 1s.
+    hashed_token = make_hashed_token()
+    await password_reset_tokens.create(username="cmyui", hashed_token=hashed_token)
+    await age_token(database, hashed_token, PASSWORD_RESET_TOKEN_TTL_SECONDS + 1)
+
+    result = await password_reset_tokens.fetch_one(hashed_token)
+
+    assert result is None
+
+
+async def test_ancient_timestamp_fails_safe_as_expired(database: Database) -> None:
+    # A degenerate/legacy `t` far in the past must fail safe (rejected + purged),
+    # never accepted. This is the "zero/garbage timestamp" direction.
+    hashed_token = make_hashed_token()
+    await password_reset_tokens.create(username="cmyui", hashed_token=hashed_token)
+    query = """\
+        UPDATE password_recovery
+        SET t = '2000-01-01 00:00:00'
+        WHERE k = :hashed_token
+    """
+    await database.execute(query, {"hashed_token": hashed_token})
+
+    result = await password_reset_tokens.fetch_one(hashed_token)
+
+    assert result is None
+    assert await count_tokens(database, hashed_token) == 0
+
+
+async def test_null_timestamp_fails_closed(database: Database) -> None:
+    # The production column is NOT NULL, so this cannot occur there; prove the
+    # defense-in-depth path anyway against a real DB by making `t` nullable for
+    # this row. A NULL age must fail closed (rejected + purged), never accepted.
+    await database.execute("ALTER TABLE password_recovery MODIFY t TIMESTAMP NULL")
+    hashed_token = make_hashed_token()
+    query = """\
+        INSERT INTO password_recovery (k, u, t)
+        VALUES (:hashed_token, :username, NULL)
+    """
+    await database.execute(query, {"hashed_token": hashed_token, "username": "cmyui"})
+
+    result = await password_reset_tokens.fetch_one(hashed_token)
+
+    assert result is None
+    assert await count_tokens(database, hashed_token) == 0

--- a/tests/unit/test_password_reset_tokens_repo.py
+++ b/tests/unit/test_password_reset_tokens_repo.py
@@ -1,0 +1,144 @@
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+import app.state
+from app.repositories import password_reset_tokens
+
+
+class FakeDatabase:
+    def __init__(self) -> None:
+        self.fetch_one_results: list[Any] = []
+        self.fetch_one_calls: list[tuple[str, dict[str, Any] | None]] = []
+        self.execute_calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def fetch_one(
+        self,
+        query: str,
+        values: dict[str, Any] | None = None,
+    ) -> Any:
+        self.fetch_one_calls.append((query, values))
+        return self.fetch_one_results.pop(0)
+
+    async def execute(
+        self,
+        query: str,
+        values: dict[str, Any] | None = None,
+    ) -> Any:
+        self.execute_calls.append((query, values))
+        return None
+
+
+@pytest.fixture
+def fake_database(monkeypatch: pytest.MonkeyPatch) -> FakeDatabase:
+    fake = FakeDatabase()
+    monkeypatch.setattr(app.state, "database", fake, raising=False)
+    return fake
+
+
+async def test_fetch_one_returns_none_for_missing_token(
+    fake_database: FakeDatabase,
+) -> None:
+    fake_database.fetch_one_results.append(None)
+
+    result = await password_reset_tokens.fetch_one("missing-token-hash")
+
+    assert result is None
+    assert fake_database.execute_calls == []
+
+
+async def test_fetch_one_returns_fresh_token_and_keeps_row(
+    fake_database: FakeDatabase,
+) -> None:
+    fake_database.fetch_one_results.append(
+        {
+            "id": 1,
+            "u": "cmyui",
+            "t": datetime(2026, 7, 7, 12, 0, 0),
+            "is_valid": 1,
+        },
+    )
+
+    result = await password_reset_tokens.fetch_one("fresh-token-hash")
+
+    assert result is not None
+    assert result.hashed_token == "fresh-token-hash"
+    assert result.username == "cmyui"
+    assert fake_database.execute_calls == []
+
+    query, params = fake_database.fetch_one_calls[0]
+    assert params is not None
+    # expiry must be judged on the DB clock, not the application clock
+    assert "TIMESTAMPDIFF" in query
+    assert "NOW()" in query
+    ttl = password_reset_tokens.PASSWORD_RESET_TOKEN_TTL_SECONDS
+    assert params["ttl_seconds"] == ttl
+
+
+async def test_fetch_one_rejects_and_deletes_expired_token(
+    fake_database: FakeDatabase,
+) -> None:
+    fake_database.fetch_one_results.append(
+        {
+            "id": 1,
+            "u": "cmyui",
+            "t": datetime(2026, 7, 7, 12, 0, 0),
+            "is_valid": 0,
+        },
+    )
+
+    result = await password_reset_tokens.fetch_one("expired-token-hash")
+
+    assert result is None
+    assert len(fake_database.execute_calls) == 1
+    query, params = fake_database.execute_calls[0]
+    assert "DELETE FROM password_recovery" in query
+    assert params == {"hashed_token": "expired-token-hash"}
+
+
+async def test_fetch_one_fails_closed_when_validity_is_null(
+    fake_database: FakeDatabase,
+) -> None:
+    # A NOT NULL `t` should never yield a NULL age, but a corrupted/migrated row
+    # must fail closed (rejected + deleted), never silently accepted.
+    fake_database.fetch_one_results.append(
+        {
+            "id": 1,
+            "u": "cmyui",
+            "t": datetime(2026, 7, 7, 12, 0, 0),
+            "is_valid": None,
+        },
+    )
+
+    result = await password_reset_tokens.fetch_one("corrupt-token-hash")
+
+    assert result is None
+    assert len(fake_database.execute_calls) == 1
+    query, params = fake_database.execute_calls[0]
+    assert "DELETE FROM password_recovery" in query
+    assert params == {"hashed_token": "corrupt-token-hash"}
+
+
+async def test_create_writes_creation_time_explicitly(
+    fake_database: FakeDatabase,
+) -> None:
+    fake_database.fetch_one_results.append(
+        {
+            "id": 1,
+            "k": "token-hash",
+            "u": "cmyui",
+            "t": datetime(2026, 7, 7, 12, 0, 0),
+        },
+    )
+
+    result = await password_reset_tokens.create(
+        username="cmyui",
+        hashed_token="token-hash",
+    )
+
+    assert result.created_at == datetime(2026, 7, 7, 12, 0, 0)
+    insert_query, insert_params = fake_database.execute_calls[0]
+    assert "INSERT INTO password_recovery (k, u, t)" in insert_query
+    assert "NOW()" in insert_query
+    assert insert_params == {"hashed_token": "token-hash", "username": "cmyui"}


### PR DESCRIPTION
password_reset_tokens.fetch_one looked tokens up by hash with no time predicate, so a reset token stayed valid indefinitely. create() also never set the `t` column, relying on the schema default.

- create() now stamps `t = NOW()` explicitly, using the same DB clock the expiry check compares against (immune to app/DB timezone or clock skew).
- fetch_one() rejects tokens at or past a 1 hour TTL (a named constant), evaluated in the same SELECT via TIMESTAMPDIFF(SECOND, t, NOW()); expired rows are deleted on read.
- The predicate is framed as "is_valid" so a NULL age fails closed (rejected) rather than being silently accepted.

Expired and unknown tokens both return None, so the usecase surfaces the existing "Invalid password reset token" and there is no expiry oracle.

Adds a pytest suite (the repo had none): DB-free repository unit tests plus integration tests covering fresh/expired/boundary/NULL cases (the latter skip cleanly when TEST_DB_DSN is unset).

Closes #18.